### PR TITLE
Cat binary files

### DIFF
--- a/memide.c
+++ b/memide.c
@@ -11,8 +11,7 @@
 #include "spinlock.h"
 #include "buf.h"
 
-//extern uchar *_binary_fs_img_start, *_binary_fs_img_size;
-uchar *_binary_fs_img_start, *_binary_fs_img_size;
+extern uchar _binary_fs_img_start[], _binary_fs_img_size[];
 
 static int disksize;
 static uchar *memdisk;

--- a/proc.c
+++ b/proc.c
@@ -87,8 +87,7 @@ void
 userinit(void)
 {
   struct proc *p;
-  // extern char _binary_initcode_start[], *_binary_initcode_size[];
-  char *_binary_initcode_start, *_binary_initcode_size;
+  extern char _binary_initcode_start[], _binary_initcode_size[];
 
   p = allocproc();
 

--- a/tools/attach_boot_header
+++ b/tools/attach_boot_header
@@ -1,0 +1,27 @@
+#!/usr/bin/env ruby
+
+require 'tempfile'
+
+def main
+  if ARGV.length < 1
+    STDERR.puts "Usage: ./attach_exec_header binary_file"
+    exit
+  end
+  attach_exec_header(ARGV[0])
+end
+
+def attach_exec_header(filename)
+  result = Tempfile.new(filename)
+  open(filename, 'rb') do |f|
+    header = [f.size].pack("l>")  # header is just a 4 byte filesize integer with big endian
+    result.write(header)
+    result.write(f.read)
+  end
+  open(filename, "wb") do |f|
+    result.rewind
+    IO.copy_stream(result, f)
+  end
+  result.unlink
+end
+
+main

--- a/tools/gen_binary_blobs
+++ b/tools/gen_binary_blobs
@@ -1,0 +1,46 @@
+#!/usr/bin/env ruby
+
+def main
+  if ARGV.length < 2
+    STDERR.puts "Usage: ./gen_binary_blob kernelsize binary_files ..."
+    exit
+  end
+  emit_binary_blobs(Integer(ARGV[0]), ARGV[1..-1])
+end
+
+def error(msg)
+  STDERR.puts "mgs"
+  exit 1
+end
+
+def emit_binary_blobs(offset, filenames)
+  out = open("_binary_blobs.s", "w")
+  filenames.each do |filename|
+    begin
+      file = open(filename)
+      labelname = c_var_name(filename)
+      out.puts <<-EOS.gsub(/^[ ]*/, "")   # unindent
+        .global _binary_#{labelname}_start
+        .set _binary_#{labelname}_start, 0x#{"%08x" % offset}
+
+        .global _binary_#{labelname}_end
+        .set _binary_#{labelname}_end, 0x#{"%08x" % (offset + file.size)}
+
+        .global _binary_#{labelname}_size
+        .set _binary_#{labelname}_size, 0x#{"%08x" % file.size}
+
+      EOS
+      offset += file.size
+      file.close
+    rescue Errno::ENOENT
+      error "No such file: #{filename}"
+    end
+  end
+  out.close
+end
+
+def c_var_name(filename)
+  filename.gsub(/^[0-9]+/, "_").gsub(/[^a-zA-Z0-9]/, "_")
+end
+
+main


### PR DESCRIPTION
@warelle initcodeとfs.imgをカーネルにリンクして、_binary_initcode_startや_binary_fs_img_startをつくります。
これらが使用されている場所もアンコメントしました。
4つある仕様箇所のうち3か所で変数の型をポインタやらなんやらから配列に変更していますが、もともとはすべてこの型でした。
多分コメントアウトの時のごたごたで間違って型が書き換えられてしまっていたのだと思います。

よろしくお願いします。